### PR TITLE
Fix pybind11 3.x and CGAL 5.x/6.x compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "geopandas>=1.1.1",
     "matplotlib>=3.10.6",
     "numpy>=2.2.6",
-    "osmx>=2.0.6",
+    "osmx>=0.0.5",
     "pyproj>=3.7.0",
     "Shapely>=2.1.1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,16 @@ authors = [
     { name = "Kasper A. R. Grontved", email = "kaspergrontved@gmail.com" },
 ]
 requires-python = ">=3.10"
+dependencies = [
+    "colorama>=0.4.6",
+    "contextily>=1.6.2",
+    "geopandas>=1.1.1",
+    "matplotlib>=3.10.6",
+    "numpy>=2.2.6",
+    "osmx>=2.0.6",
+    "pyproj>=3.7.0",
+    "Shapely>=2.1.1",
+]
 classifiers = [
     "Development Status :: 4 - Beta",
     "License :: OSI Approved :: MIT License",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "geopandas>=1.1.1",
     "matplotlib>=3.10.6",
     "numpy>=2.2.6",
-    "osmx>=0.0.5",
+    "osmnx>=1.9.0",
     "pyproj>=3.7.0",
     "Shapely>=2.1.1",
 ]

--- a/trajgenpy_bindings/Bindings.cpp
+++ b/trajgenpy_bindings/Bindings.cpp
@@ -144,7 +144,7 @@ PYBIND11_MODULE(bindings, m)
     py::class_<PolygonWithHoles>(m, "Polygon_with_holes_2")
         .def(py::init<>([](const Polygon_2 poly)
                         { return PolygonWithHoles(poly); }))
-        .def("add_hole", &PolygonWithHoles::add_hole)
+        .def("add_hole", [](PolygonWithHoles& pwh, const Polygon_2& hole) { pwh.add_hole(hole); })
         .def_property_readonly("holes", [](PolygonWithHoles &p) -> std::vector<Polygon_2>
                                {
             std::vector<Polygon_2> holes;

--- a/trajgenpy_bindings/bcd.cc
+++ b/trajgenpy_bindings/bcd.cc
@@ -21,6 +21,7 @@
 
 #include "bcd.h"
 #include "cgal_comm.h"
+#include "cgal_variant_compat.h"
 #include <cassert>
 namespace polygon_coverage_planning
 {
@@ -444,13 +445,13 @@ namespace polygon_coverage_planning
             Intersection result = CGAL::intersection(*it, l);
             if (result)
             {
-                if (boost::get<Segment_2>(&*result))
+                if (cgal_compat::get_variant<Segment_2>(&*result))
                 {
                     *(intersection++) = it->target();
                 }
                 else
                 {
-                    const Point_2 *p = boost::get<Point_2>(&*result);
+                    const Point_2 *p = cgal_compat::get_variant<Point_2>(&*result);
                     *(intersection++) = *p;
                 }
             }

--- a/trajgenpy_bindings/include/cgal_variant_compat.h
+++ b/trajgenpy_bindings/include/cgal_variant_compat.h
@@ -1,0 +1,46 @@
+#ifndef CGAL_VARIANT_COMPAT_H
+#define CGAL_VARIANT_COMPAT_H
+
+#include <CGAL/version.h>
+#include <boost/variant.hpp>
+
+// CGAL 6.0+ uses std::variant, earlier versions use boost::variant
+#if CGAL_VERSION_NR >= 1060000000
+    #include <variant>
+    #define CGAL_USES_STD_VARIANT 1
+#else
+    #define CGAL_USES_STD_VARIANT 0
+#endif
+
+namespace cgal_compat {
+
+// Template function to get value from either boost::variant or std::variant
+// Works like std::get_if or boost::get for pointer access
+
+#if CGAL_USES_STD_VARIANT
+    // For CGAL 6.0+ with std::variant
+    template<typename T, typename... Types>
+    inline T* get_variant(std::variant<Types...>* var) {
+        return std::get_if<T>(var);
+    }
+    
+    template<typename T, typename... Types>
+    inline const T* get_variant(const std::variant<Types...>* var) {
+        return std::get_if<T>(var);
+    }
+#else
+    // For CGAL 5.x with boost::variant
+    template<typename T, typename... Types>
+    inline T* get_variant(boost::variant<Types...>* var) {
+        return boost::get<T>(var);
+    }
+    
+    template<typename T, typename... Types>
+    inline const T* get_variant(const boost::variant<Types...>* var) {
+        return boost::get<T>(var);
+    }
+#endif
+
+} // namespace cgal_compat
+
+#endif // CGAL_VARIANT_COMPAT_H

--- a/trajgenpy_bindings/sweep.cc
+++ b/trajgenpy_bindings/sweep.cc
@@ -19,6 +19,7 @@
 
 #include "sweep.h"
 
+#include "cgal_variant_compat.h"
 namespace polygon_coverage_planning
 {
 
@@ -207,14 +208,14 @@ namespace polygon_coverage_planning
             Intersection result = CGAL::intersection(*it, l);
             if (result)
             {
-                if (const Segment_2 *s = boost::get<Segment_2>(&*result))
+                if (const Segment_2 *s = cgal_compat::get_variant<Segment_2>(&*result))
                 {
                     intersections.push_back(s->source());
                     intersections.push_back(s->target());
                 }
                 else
                 {
-                    intersections.push_back(*boost::get<Point_2>(&*result));
+                    intersections.push_back(*cgal_compat::get_variant<Point_2>(&*result));
                 }
             }
         }

--- a/trajgenpy_bindings/visibility_polygon.cc
+++ b/trajgenpy_bindings/visibility_polygon.cc
@@ -21,6 +21,7 @@
 #include <CGAL/Arr_segment_traits_2.h>
 #include <CGAL/Triangular_expansion_visibility_2.h>
 
+#include "cgal_variant_compat.h"
 #include "cgal_comm.h"
 #include "visibility_polygon.h"
 namespace polygon_coverage_planning
@@ -78,12 +79,12 @@ namespace polygon_coverage_planning
         typedef VisibilityArrangement::Face_handle VisibilityFaceHandle;
         VisibilityFaceHandle fh;
         VisibilityArrangement visibility_arr;
-        if ((f = boost::get<VisibilityArrangement::Face_const_handle>(&pl_result)))
+        if ((f = cgal_compat::get_variant<VisibilityArrangement::Face_const_handle>(&pl_result)))
         {
             // Located in face.
             fh = tev.compute_visibility(query_point, *f, visibility_arr);
         }
-        else if ((v = boost::get<VisibilityArrangement::Vertex_const_handle>(
+        else if ((v = cgal_compat::get_variant<VisibilityArrangement::Vertex_const_handle>(
                       &pl_result)))
         {
             // Located on vertex.
@@ -102,7 +103,7 @@ namespace polygon_coverage_planning
 
             fh = tev.compute_visibility(query_point, he, visibility_arr);
         }
-        else if ((e = boost::get<VisibilityArrangement::Halfedge_const_handle>(
+        else if ((e = cgal_compat::get_variant<VisibilityArrangement::Halfedge_const_handle>(
                       &pl_result)))
         {
             // Located on halfedge.


### PR DESCRIPTION
## Summary
Fixes compilation errors with pybind11 3.x and adds compatibility for both CGAL 5.x and 6.x.

## Changes

### 1. pybind11 3.x Compatibility (Bindings.cpp)
- Fixed `add_hole` overload ambiguity using lambda wrapper
- pybind11 3.x requires explicit disambiguation for overloaded methods

### 2. CGAL 5.x/6.x Compatibility
- Added `cgal_variant_compat.h` with version detection
- CGAL 6.0+ changed from `boost::variant` to `std::variant`
- Provides unified `cgal_compat::get_variant()` that works with both versions
- Updated `bcd.cc`, `sweep.cc`, `visibility_polygon.cc` to use compatibility wrapper

### 3. Runtime Dependencies
- Added missing dependencies to `pyproject.toml`:
  - colorama, contextily, geopandas, matplotlib, numpy
  - osmnx (corrected from osmx), pyproj, Shapely

## Testing
- ✅ Tested with CGAL 5.6 (Ubuntu Noble)
- ✅ Tested with CGAL 6.0 (Debian Trixie)
- ✅ Docker builds successfully
- ✅ All imports and C++ bindings functional

## Fixes
- Resolves build failures with modern build environments
- Enables trajgenpy to work in Docker containers
- Makes the package properly installable via pip with automatic dependency resolution