### PR TITLE
docs: add MkDocs site, comprehensive docstrings, and GitHub Pages publishing

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,49 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches:
+      - main
+  # Allow manual trigger from the Actions tab
+  workflow_dispatch:
+
+# Allow the workflow to write to the gh-pages branch
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # Fetch full history so mkdocs can generate correct revision dates
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcgal-dev pybind11-dev
+
+      - name: Install library (needed for mkdocstrings API autodoc)
+        run: uv pip install --system . --verbose
+
+      - name: Install documentation dependencies
+        run: |
+          uv pip install --system \
+            mkdocs \
+            mkdocs-material \
+            "mkdocstrings[python]"
+
+      - name: Build and deploy to GitHub Pages
+        run: mkdocs gh-deploy --force

--- a/docs/api/geometries.md
+++ b/docs/api/geometries.md
@@ -1,0 +1,57 @@
+# trajgenpy.Geometries
+
+CRS-aware geometry wrappers and coverage-planning algorithms.
+
+---
+
+## Geometry classes
+
+::: trajgenpy.Geometries.GeoData
+
+---
+
+::: trajgenpy.Geometries.GeoPoint
+
+---
+
+::: trajgenpy.Geometries.GeoPolygon
+
+---
+
+::: trajgenpy.Geometries.GeoMultiPolygon
+
+---
+
+::: trajgenpy.Geometries.GeoTrajectory
+
+---
+
+::: trajgenpy.Geometries.GeoMultiTrajectory
+
+---
+
+## Planning functions
+
+::: trajgenpy.Geometries.get_sweep_offset
+
+---
+
+::: trajgenpy.Geometries.decompose_polygon
+
+---
+
+::: trajgenpy.Geometries.generate_sweep_pattern
+
+---
+
+## Low-level helpers
+
+::: trajgenpy.Geometries.is_convex
+
+---
+
+::: trajgenpy.Geometries.shapely_polygon_to_cgal
+
+---
+
+::: trajgenpy.Geometries.multi_polygon_to_polygon_with_holes

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,0 +1,45 @@
+# API Reference
+
+TrajGenPy exposes three public Python modules:
+
+| Module | Purpose |
+|---|---|
+| [`trajgenpy.Geometries`](geometries.md) | CRS-aware geometry wrappers and coverage-planning algorithms |
+| [`trajgenpy.Query`](query.md) | OpenStreetMap feature querying and GeoJSON export |
+| [`trajgenpy.Utils`](utils.md) | Basemap visualisation and coordinate normalisation |
+
+The coloured logging system used internally is documented in
+[`trajgenpy.Logging`](logging.md).
+
+---
+
+## Module overview
+
+### Geometries
+
+The core module.  It provides:
+
+- **Geometry wrappers** (`GeoData`, `GeoPoint`, `GeoPolygon`, `GeoMultiPolygon`,
+  `GeoTrajectory`, `GeoMultiTrajectory`) — Shapely geometries augmented with CRS
+  tracking and automatic reprojection via pyproj.
+- **Planning functions**:
+    - `decompose_polygon` — Boustrophedon Cell Decomposition of a (possibly holed) polygon.
+    - `generate_sweep_pattern` — Parallel sweep lines over a convex cell.
+    - `get_sweep_offset` — Sensor-based sweep spacing calculation.
+    - `shapely_polygon_to_cgal` — Low-level conversion to CGAL's `Polygon_2`.
+    - `is_convex` — Convexity test.
+
+### Query
+
+Thin wrapper around [OSMnx](https://osmnx.readthedocs.io/) for extracting
+real-world geographic features:
+
+- `query_features` — Fetch OSM features by tag within an area of interest.
+- `export_as_geojson` — Write a coverage plan to a `FeatureCollection` GeoJSON file.
+
+### Utils
+
+Visualisation helpers:
+
+- `plot_basemap` — Add a contextily tile layer to a Matplotlib figure.
+- `normalize_coordinates` — Translate geometries to a local origin.

--- a/docs/api/logging.md
+++ b/docs/api/logging.md
@@ -1,0 +1,16 @@
+# trajgenpy.Logging
+
+Coloured logging setup for TrajGenPy.
+
+This module is initialised automatically on first import.  You generally do
+not need to call anything in it directly — just use the standard
+:mod:`logging` module with the ``"trajgenpy"`` logger name, or obtain the
+pre-configured logger via :func:`~trajgenpy.Logging.get_logger`.
+
+---
+
+::: trajgenpy.Logging.get_logger
+
+---
+
+::: trajgenpy.Logging.init_logger

--- a/docs/api/query.md
+++ b/docs/api/query.md
@@ -1,0 +1,11 @@
+# trajgenpy.Query
+
+OpenStreetMap feature querying and GeoJSON export.
+
+---
+
+::: trajgenpy.Query.query_features
+
+---
+
+::: trajgenpy.Query.export_as_geojson

--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -1,0 +1,11 @@
+# trajgenpy.Utils
+
+Visualisation and coordinate normalisation helpers.
+
+---
+
+::: trajgenpy.Utils.plot_basemap
+
+---
+
+::: trajgenpy.Utils.normalize_coordinates

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,93 @@
+# Contributing
+
+Thank you for considering contributing to TrajGenPy!
+
+---
+
+## Getting started
+
+1. **Fork** the repository on GitHub.
+2. **Clone** your fork locally:
+   ```bash
+   git clone https://github.com/<your-username>/trajgenpy.git
+   cd trajgenpy
+   ```
+3. **Install** system dependencies:
+   ```bash
+   sudo apt-get install -y libcgal-dev pybind11-dev
+   ```
+4. **Install** the package in editable mode (rebuilds the C++ extension):
+   ```bash
+   pip install -e .
+   ```
+
+---
+
+## Development workflow
+
+Create a feature branch, make changes, then open a pull request:
+
+```bash
+git checkout -b feature/my-improvement
+# ... edit code ...
+git commit -m "feat: describe the change"
+git push origin feature/my-improvement
+```
+
+---
+
+## Running tests
+
+```bash
+pip install pytest
+pytest tests/
+```
+
+---
+
+## Linting
+
+```bash
+pip install ruff
+ruff check .
+```
+
+---
+
+## Rebuilding C++ bindings
+
+After modifying any file in `trajgenpy_bindings/`, rebuild the extension:
+
+```bash
+pip install -e .
+```
+
+---
+
+## Building the documentation locally
+
+```bash
+pip install mkdocs mkdocs-material mkdocstrings[python]
+mkdocs serve
+```
+
+Open `http://127.0.0.1:8000` in your browser.  The docs auto-reload on save.
+
+---
+
+## Code style
+
+- Follow PEP 8; the project uses **ruff** for linting (see `pyproject.toml` for rules).
+- Add Google-style docstrings to all public functions and classes.
+- Write tests for any new functionality in `tests/`.
+
+---
+
+## Reporting issues
+
+Open an issue on the [GitHub repository](https://github.com/kasperg3/trajgenpy/issues).
+Please include a minimal reproducible example and the output of:
+
+```bash
+python -c "import trajgenpy; print(trajgenpy.__version__)"
+```

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,143 @@
+# Examples
+
+The `examples/` directory in the repository contains runnable scripts that
+demonstrate the most common TrajGenPy workflows.
+
+---
+
+## Basic sweep over a synthetic polygon
+
+**File:** `examples/coverage_and_plotting.py`
+
+Demonstrates sweep pattern generation over a simple polygon defined in a
+metric coordinate system.
+
+```python
+import shapely
+import matplotlib.pyplot as plt
+from trajgenpy.Geometries import (
+    GeoPolygon,
+    GeoMultiTrajectory,
+    decompose_polygon,
+    generate_sweep_pattern,
+    get_sweep_offset,
+)
+
+boundary = shapely.Polygon(
+    [(0, 0), (500, 0), (500, 300), (250, 400), (0, 300)]
+)
+area = GeoPolygon(boundary, crs="EPSG:32632")
+
+cells = decompose_polygon(area.geometry)
+offset = get_sweep_offset(overlap=0.1, height=20, field_of_view=90)
+
+all_sweeps = []
+for cell in cells:
+    all_sweeps.extend(generate_sweep_pattern(cell, offset))
+
+fig, ax = plt.subplots(figsize=(8, 6))
+area.plot(ax=ax, facecolor="lightgreen", edgecolor="darkgreen", alpha=0.4)
+GeoMultiTrajectory(all_sweeps, crs="EPSG:32632").plot(ax=ax, color="crimson")
+plt.axis("equal")
+plt.title(f"Coverage plan — {len(all_sweeps)} sweep lines")
+plt.show()
+```
+
+---
+
+## Coverage with obstacles
+
+**File:** `examples/coverage_and_plotting.py`
+
+Demonstrates how to pass keep-out zones (obstacles) to the decomposition.
+The planner merges obstacles that intersect the boundary automatically.
+
+```python
+import shapely
+import matplotlib.pyplot as plt
+from trajgenpy.Geometries import (
+    GeoPolygon,
+    GeoMultiPolygon,
+    GeoMultiTrajectory,
+    decompose_polygon,
+    generate_sweep_pattern,
+    get_sweep_offset,
+)
+
+boundary = shapely.box(0, 0, 400, 300)
+obstacles = shapely.MultiPolygon([
+    shapely.box(80, 80, 160, 160),
+    shapely.box(240, 100, 320, 200),
+])
+
+cells = decompose_polygon(boundary, obstacles=obstacles)
+offset = get_sweep_offset(overlap=0.0, height=15, field_of_view=90)
+
+all_sweeps = []
+for cell in cells:
+    all_sweeps.extend(generate_sweep_pattern(cell, offset))
+
+fig, ax = plt.subplots(figsize=(8, 6))
+GeoPolygon(boundary, crs="EPSG:32632").plot(
+    ax=ax, facecolor="lightblue", edgecolor="navy", alpha=0.3
+)
+GeoMultiPolygon(list(obstacles.geoms), crs="EPSG:32632").plot(
+    ax=ax, facecolor="salmon", edgecolor="red", alpha=0.6
+)
+GeoMultiTrajectory(all_sweeps, crs="EPSG:32632").plot(ax=ax, color="blue")
+plt.axis("equal")
+plt.title(f"{len(cells)} cells — {len(all_sweeps)} sweep lines")
+plt.show()
+```
+
+---
+
+## OSM feature extraction and coverage
+
+**File:** `examples/coverage_on_queried_data.py`
+
+Queries real land-use features from OpenStreetMap and generates a coverage
+plan over the result.
+
+```python
+import shapely
+import matplotlib.pyplot as plt
+from trajgenpy.Geometries import GeoPolygon, GeoMultiTrajectory, decompose_polygon, generate_sweep_pattern, get_sweep_offset
+from trajgenpy.Query import query_features
+from trajgenpy.Utils import plot_basemap
+
+# Define query area in WGS84
+area = GeoPolygon(shapely.box(10.38, 55.38, 10.42, 55.42))
+
+# Fetch features from OSM
+tags = {"natural": True, "landuse": True}
+features = query_features(area, tags)
+
+# Reproject to UTM for planning
+area.set_crs("EPSG:32632")
+cells = decompose_polygon(area.geometry)
+offset = get_sweep_offset(overlap=0.1, height=30, field_of_view=90)
+
+all_sweeps = []
+for cell in cells:
+    all_sweeps.extend(generate_sweep_pattern(cell, offset))
+
+# Plot with satellite basemap
+fig, ax = plt.subplots(figsize=(10, 8))
+area.plot(ax=ax, facecolor="none", edgecolor="white", linewidth=2)
+GeoMultiTrajectory(all_sweeps, crs="EPSG:32632").plot(ax=ax, color="yellow")
+plot_basemap(ax=ax, crs="EPSG:32632")
+plt.show()
+```
+
+---
+
+## Interactive Jupyter notebook
+
+An interactive version of the examples above is available in the repository
+as `examples/examples.ipynb`.  Open it with:
+
+```bash
+pip install jupyter
+jupyter notebook examples/examples.ipynb
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,105 @@
+# TrajGenPy
+
+[![Build Status](https://github.com/kasperg3/trajgenpy/actions/workflows/test.yml/badge.svg)](https://github.com/kasperg3/trajgenpy/actions/workflows/test.yml)
+[![PyPI version](https://img.shields.io/pypi/v/trajgenpy.svg)](https://pypi.org/project/trajgenpy/)
+![License](https://img.shields.io/badge/license-MIT-blue.svg)
+[![Python Version](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
+
+**TrajGenPy** is a Python library for generating coverage trajectories over arbitrary
+polygonal areas using the **Boustrophedon Cell Decomposition** algorithm.
+
+---
+
+## What does it do?
+
+Given an area of interest (and optional obstacle polygons), TrajGenPy will:
+
+1. **Decompose** the area into convex, weakly-monotone cells via the CGAL-backed
+   Boustrophedon Cell Decomposition.
+2. **Generate** parallel sweep ("lawnmower") lines for each cell with a configurable
+   inter-sweep distance and overlap ratio.
+3. **Export** the resulting trajectory as Shapely geometries or GeoJSON — ready for
+   use with any flight/robot controller.
+
+It also provides helpers for **querying real-world features** from OpenStreetMap and
+**reprojecting** geometries between coordinate reference systems.
+
+---
+
+## Key Features
+
+| Feature | Description |
+|---|---|
+| Boustrophedon decomposition | Splits non-convex polygons into convex cells |
+| Configurable sweep offset | Derived from sensor height, FoV, and desired overlap |
+| Obstacle avoidance | Holes in the boundary polygon are respected |
+| CRS-aware geometry wrappers | Convert between WGS84 and any projected CRS |
+| OSM feature extraction | Query buildings, roads, land use, and more |
+| GeoJSON export | Save plans as standard GeoJSON FeatureCollections |
+
+---
+
+## Quick example
+
+```python
+import shapely
+from trajgenpy.Geometries import (
+    GeoPolygon,
+    decompose_polygon,
+    generate_sweep_pattern,
+    get_sweep_offset,
+)
+
+# 1. Define an area in WGS84 and reproject to UTM for metric planning
+area = GeoPolygon(shapely.box(10.38, 55.38, 10.42, 55.42))
+area.set_crs("EPSG:32632")
+
+# 2. Decompose into convex cells
+cells = decompose_polygon(area.geometry)
+
+# 3. Generate a sweep pattern (20 m height, 90° FoV, 10% overlap)
+offset = get_sweep_offset(overlap=0.1, height=20, field_of_view=90)
+for cell in cells:
+    sweeps = generate_sweep_pattern(cell, offset)
+    print(f"Cell covered by {len(sweeps)} sweep lines")
+```
+
+---
+
+## Installation
+
+=== "pip (recommended)"
+
+    ```bash
+    # System dependencies (Ubuntu/Debian)
+    sudo apt-get install -y libcgal-dev pybind11-dev
+
+    pip install trajgenpy
+    ```
+
+=== "From source"
+
+    ```bash
+    sudo apt-get install -y libcgal-dev pybind11-dev
+    git clone https://github.com/kasperg3/trajgenpy.git
+    cd trajgenpy
+    pip install -e .
+    ```
+
+See the [Installation guide](installation.md) for full details.
+
+---
+
+## Citation
+
+If you use TrajGenPy in academic work, please cite:
+
+```bibtex
+@inproceedings{grontved2022icar,
+  title     = {Decentralized Multi-UAV Trajectory Task Allocation in Search and Rescue Applications},
+  author    = {Gr{\o}ntved, Kasper Andreas R{\o}mer and Schultz, Ulrik Pagh and Christensen, Anders Lyhne},
+  booktitle = {21st International Conference on Advanced Robotics},
+  year      = {2023},
+  organization = {IEEE}
+}
+```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,93 @@
+# Installation
+
+TrajGenPy has a C++ extension built with [CGAL](https://www.cgal.org/) and
+[pybind11](https://pybind11.readthedocs.io/), so you need the system libraries
+before installing the Python package.
+
+---
+
+## System requirements
+
+| Requirement | Version | Notes |
+|---|---|---|
+| Python | ≥ 3.10 | CPython only |
+| libcgal-dev | any | Computational Geometry Algorithms Library |
+| pybind11-dev | any | C++/Python bindings header library |
+| cmake | ≥ 3.15 | Required when building from source |
+
+### Ubuntu / Debian
+
+```bash
+sudo apt-get update
+sudo apt-get install -y libcgal-dev pybind11-dev
+```
+
+### macOS (Homebrew)
+
+```bash
+brew install cgal pybind11
+```
+
+!!! note
+    Pre-built wheels on PyPI include the compiled extension, so macOS and
+    Windows users who install a published wheel do **not** need CGAL or pybind11
+    at runtime.
+
+---
+
+## Install from PyPI
+
+Once the system dependencies are present, install with pip:
+
+```bash
+pip install trajgenpy
+```
+
+The package is regularly updated; upgrade to the latest release with:
+
+```bash
+pip install --upgrade trajgenpy
+```
+
+---
+
+## Build from source
+
+Use this approach if you want the latest unreleased changes or need to modify
+the C++ bindings.
+
+```bash
+# 1. Clone the repository
+git clone https://github.com/kasperg3/trajgenpy.git
+cd trajgenpy
+
+# 2. Install Python dependencies
+pip install -r requirements.txt
+
+# 3. Build and install in editable mode
+#    (re-run this step if you change any C++ code)
+pip install -e .
+```
+
+The `-e` flag (editable install) means Python source changes are reflected
+immediately without reinstalling, but you **must** re-run `pip install -e .`
+after every change to the C++ extension code in `trajgenpy_bindings/`.
+
+---
+
+## Verify the installation
+
+```python
+import trajgenpy
+print(trajgenpy.__version__)
+
+# Quick functional check
+import shapely
+from trajgenpy.Geometries import decompose_polygon, generate_sweep_pattern, get_sweep_offset
+
+poly = shapely.box(0, 0, 100, 100)
+cells = decompose_polygon(poly)
+offset = get_sweep_offset(overlap=0.1, height=10, field_of_view=90)
+sweeps = generate_sweep_pattern(cells[0], offset)
+print(f"Generated {len(sweeps)} sweep lines — installation OK")
+```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,150 @@
+# Quick Start
+
+This guide walks through the most common TrajGenPy workflows, from a simple
+synthetic polygon to a real-world OSM-based coverage plan.
+
+---
+
+## 1. Sweep a simple polygon
+
+```python
+import shapely
+import matplotlib.pyplot as plt
+from trajgenpy.Geometries import (
+    GeoPolygon,
+    GeoMultiTrajectory,
+    decompose_polygon,
+    generate_sweep_pattern,
+    get_sweep_offset,
+)
+
+# --- Define area ---
+polygon = shapely.Polygon([(0, 0), (200, 0), (200, 150), (100, 200), (0, 150)])
+area = GeoPolygon(polygon, crs="EPSG:32632")  # UTM zone 32N (metres)
+
+# --- Decompose into convex cells ---
+cells = decompose_polygon(area.geometry)
+print(f"Decomposed into {len(cells)} cell(s)")
+
+# --- Compute sweep offset (10 m height, 90° FoV, 10% overlap) ---
+offset = get_sweep_offset(overlap=0.1, height=10, field_of_view=90)
+
+# --- Generate and plot sweep patterns ---
+fig, ax = plt.subplots()
+area.plot(ax=ax, facecolor="lightblue", edgecolor="navy")
+
+all_sweeps = []
+for cell in cells:
+    sweeps = generate_sweep_pattern(cell, offset)
+    all_sweeps.extend(sweeps)
+
+GeoMultiTrajectory(all_sweeps, crs="EPSG:32632").plot(ax=ax, color="red")
+plt.axis("equal")
+plt.show()
+```
+
+---
+
+## 2. Add obstacles (keep-out zones)
+
+```python
+import shapely
+from trajgenpy.Geometries import decompose_polygon, generate_sweep_pattern, get_sweep_offset
+
+boundary = shapely.box(0, 0, 300, 300)
+obstacle = shapely.box(100, 100, 200, 200)  # square hole in the middle
+
+cells = decompose_polygon(boundary, obstacles=obstacle)
+offset = get_sweep_offset(overlap=0.0, height=15, field_of_view=60)
+
+sweeps = []
+for cell in cells:
+    sweeps.extend(generate_sweep_pattern(cell, offset))
+
+print(f"{len(sweeps)} sweep segments over {len(cells)} cells")
+```
+
+---
+
+## 3. Work with real-world coordinates
+
+TrajGenPy geometry wrappers are CRS-aware.  Always reproject from WGS84 to a
+metric CRS before planning so that distances are in metres.
+
+```python
+import shapely
+from trajgenpy.Geometries import GeoPolygon, decompose_polygon, generate_sweep_pattern, get_sweep_offset
+
+# Bounding box near Odense, Denmark (WGS84)
+area = GeoPolygon(shapely.box(10.38, 55.38, 10.42, 55.42))
+
+# Reproject to UTM zone 32N (EPSG:32632) for metric planning
+area.set_crs("EPSG:32632")
+
+cells = decompose_polygon(area.geometry)
+offset = get_sweep_offset(overlap=0.1, height=30, field_of_view=90)
+
+all_sweeps = []
+for cell in cells:
+    all_sweeps.extend(generate_sweep_pattern(cell, offset))
+
+print(f"Plan: {len(all_sweeps)} sweeps over {area.geometry.area / 1e6:.2f} km²")
+```
+
+---
+
+## 4. Query features from OpenStreetMap
+
+```python
+import shapely
+import matplotlib.pyplot as plt
+from trajgenpy.Geometries import GeoPolygon, GeoMultiTrajectory, decompose_polygon, generate_sweep_pattern, get_sweep_offset
+from trajgenpy.Query import query_features
+from trajgenpy.Utils import plot_basemap
+
+# --- Query area in WGS84 ---
+area_wgs84 = GeoPolygon(shapely.box(10.38, 55.38, 10.42, 55.42))
+
+# --- Fetch land-use and natural features from OSM ---
+tags = {"landuse": True, "natural": True}
+features = query_features(area_wgs84, tags)
+
+# --- Reproject for planning ---
+area_wgs84.set_crs("EPSG:32632")
+
+# --- Plan coverage ---
+cells = decompose_polygon(area_wgs84.geometry)
+offset = get_sweep_offset(overlap=0.1, height=20, field_of_view=90)
+sweeps = [s for cell in cells for s in generate_sweep_pattern(cell, offset)]
+
+# --- Plot ---
+fig, ax = plt.subplots(figsize=(10, 8))
+area_wgs84.plot(ax=ax, facecolor="none", edgecolor="black")
+GeoMultiTrajectory(sweeps, crs="EPSG:32632").plot(ax=ax, color="red")
+plt.show()
+```
+
+---
+
+## 5. Export to GeoJSON
+
+```python
+from trajgenpy.Query import export_as_geojson
+
+# Assumes `boundary`, `obstacles`, `sweeps` are available from previous steps
+export_as_geojson(
+    boundary=area_wgs84.geometry,
+    obstacles=[],          # pass a list of Shapely Polygons
+    features=sweeps,
+    crs="EPSG:32632",
+)
+# Creates output.json in the current directory
+```
+
+---
+
+## Next steps
+
+- Read the [API Reference](api/index.md) for full parameter documentation.
+- Browse the [Examples](examples.md) for complete runnable scripts.
+- Check out the Jupyter notebook at `examples/examples.ipynb` for interactive exploration.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,88 @@
+site_name: TrajGenPy
+site_description: Coverage trajectory generation using Boustrophedon Cell Decomposition
+site_url: https://kasperg3.github.io/trajgenpy
+repo_name: kasperg3/trajgenpy
+repo_url: https://github.com/kasperg3/trajgenpy
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  palette:
+    - scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - navigation.footer
+    - search.highlight
+    - search.suggest
+    - content.code.annotate
+    - content.code.copy
+    - content.action.edit
+
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          paths: [.]
+          options:
+            docstring_style: google
+            show_source: true
+            show_root_heading: true
+            show_root_toc_entry: true
+            show_category_heading: true
+            members_order: source
+            heading_level: 2
+
+nav:
+  - Home: index.md
+  - Installation: installation.md
+  - Quick Start: quickstart.md
+  - API Reference:
+      - Overview: api/index.md
+      - Geometries: api/geometries.md
+      - Query: api/query.md
+      - Utils: api/utils.md
+      - Logging: api/logging.md
+  - Examples: examples.md
+  - Contributing: contributing.md
+
+markdown_extensions:
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
+  - attr_list
+  - md_in_html
+  - tables
+  - footnotes
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/kasperg3/trajgenpy
+    - icon: fontawesome/brands/python
+      link: https://pypi.org/project/trajgenpy/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,11 @@ minimum-version = "build-system.requires"
 
 [project.optional-dependencies]
 test = ["pytest"]
+docs = [
+    "mkdocs",
+    "mkdocs-material",
+    "mkdocstrings[python]",
+]
 
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/trajgenpy/Geometries.py
+++ b/trajgenpy/Geometries.py
@@ -1,3 +1,17 @@
+"""Geometry classes and coverage-planning utilities for TrajGenPy.
+
+This module provides CRS-aware wrappers around Shapely geometry types and the
+core algorithmic functions needed for coverage path planning:
+
+- **GeoData** – abstract base for all geometry wrappers.
+- **GeoTrajectory** / **GeoMultiTrajectory** – single and multi-path trajectories.
+- **GeoPoint** – single geographic point.
+- **GeoPolygon** / **GeoMultiPolygon** – area representations with holes.
+- :func:`decompose_polygon` – Boustrophedon Cell Decomposition via CGAL.
+- :func:`generate_sweep_pattern` – boustrophedon sweep lines over a single cell.
+- :func:`get_sweep_offset` – calculate inter-sweep spacing from sensor parameters.
+"""
+
 import math
 
 import geojson
@@ -13,11 +27,38 @@ log = Logging.get_logger()
 
 
 class GeoData:
+    """Abstract base class for CRS-aware geometry wrappers.
+
+    All concrete geometry classes (e.g. :class:`GeoPolygon`,
+    :class:`GeoTrajectory`) inherit from this class.  It stores a Shapely
+    geometry together with its coordinate reference system string and provides
+    common operations such as CRS conversion, buffering, and GeoJSON export.
+
+    Args:
+        geometry: Any Shapely geometry object.
+        crs: EPSG string or ``"WGS84"`` identifying the geometry's CRS.
+            Defaults to ``"WGS84"``.
+    """
+
     def __init__(self, geometry, crs="WGS84"):
         self.geometry = geometry
         self.crs = crs
 
     def set_crs(self, crs):
+        """Reproject the geometry to a new coordinate reference system.
+
+        If *crs* differs from the current CRS the geometry coordinates are
+        transformed in-place using :mod:`pyproj`.
+
+        Args:
+            crs: Target CRS as a string (e.g. ``"EPSG:32632"``).
+
+        Returns:
+            GeoData: ``self`` (for method chaining).
+
+        Raises:
+            ValueError: If *crs* is not a string.
+        """
         if not isinstance(crs, str):
             msg = "New CRS must be a string."
             raise ValueError(msg)
@@ -33,14 +74,47 @@ class GeoData:
         raise NotImplementedError(msg)
 
     def is_geometry_of_type(self, geometry, expected_class):
+        """Raise :exc:`ValueError` if *geometry* is not an instance of *expected_class*.
+
+        Args:
+            geometry: The geometry object to check.
+            expected_class: The expected type (or union of types).
+
+        Raises:
+            ValueError: When the type check fails.
+        """
         if expected_class and not isinstance(geometry, expected_class):
             msg = f"Geometry must be a {expected_class.__name__}."
             raise ValueError(msg)
 
     def get_geometry(self):
+        """Return the underlying Shapely geometry object.
+
+        Returns:
+            shapely.geometry.base.BaseGeometry: The wrapped Shapely geometry.
+        """
         return self.geometry
 
     def buffer(self, distance, quad_segs=1, cap_style="square", join_style="bevel"):
+        """Expand or contract the geometry by *distance* units.
+
+        Delegates to :meth:`shapely.geometry.base.BaseGeometry.buffer`.  The
+        geometry is replaced in-place.
+
+        Args:
+            distance: Buffer distance in the geometry's CRS units (metres for
+                metric CRS, degrees for WGS84).  Negative values shrink the
+                geometry.
+            quad_segs: Number of segments used to approximate a quarter circle
+                (default ``1`` for a rectilinear buffer).
+            cap_style: End-cap style for linear geometries.  One of
+                ``"round"``, ``"flat"``, or ``"square"`` (default).
+            join_style: Corner join style.  One of ``"round"``, ``"mitre"``,
+                or ``"bevel"`` (default).
+
+        Returns:
+            GeoData: ``self`` (for method chaining).
+        """
         self.geometry = self.geometry.buffer(distance, quad_segs, cap_style, join_style)
         return self
 
@@ -51,6 +125,20 @@ class GeoData:
         return self.geometry.__geo_interface__
 
     def to_geojson(self, id=None, name=None, properties=None):
+        """Serialise the geometry as a GeoJSON :class:`geojson.Feature`.
+
+        Args:
+            id: Feature identifier.  A random integer is used when ``None``
+                (default).
+            name: Human-readable name stored in ``properties["name"]``.
+                Defaults to ``str(id)``.
+            properties: Additional key/value pairs to include in the feature
+                properties.  The keys ``"crs"`` and ``"name"`` are added
+                automatically.
+
+        Returns:
+            geojson.Feature: The serialised feature.
+        """
         if id is None:
             id = random.randint(0, 1000000000)
         if name is None:
@@ -64,11 +152,35 @@ class GeoData:
 
 
 class GeoTrajectory(GeoData):
+    """CRS-aware wrapper for a single-path trajectory (Shapely :class:`~shapely.LineString`).
+
+    Args:
+        geometry: A Shapely :class:`~shapely.LineString` representing the path.
+        crs: Coordinate reference system string.  Defaults to ``"WGS84"``.
+
+    Raises:
+        ValueError: If *geometry* is not a :class:`~shapely.LineString`.
+    """
+
     def __init__(self, geometry, crs="WGS84"):
         self.is_geometry_of_type(geometry, shapely.LineString)
         super().__init__(geometry, crs)
 
     def plot(self, ax=None, add_points=True, color=None, linewidth=2, **kwargs):
+        """Render the trajectory on a Matplotlib axes.
+
+        A warning is issued when the current CRS is ``"WGS84"`` because
+        geographic coordinates distort the visual representation.
+
+        Args:
+            ax: Matplotlib :class:`~matplotlib.axes.Axes` to draw on.
+                Uses the current active axes when ``None``.
+            add_points: Overlay vertex markers when ``True`` (default).
+            color: Line colour accepted by Matplotlib.
+            linewidth: Stroke width in points (default ``2``).
+            **kwargs: Additional keyword arguments forwarded to
+                :func:`shapely.plotting.plot_line`.
+        """
         if self.crs == "WGS84":
             log.warning(
                 "Plotting in WGS84 is not recomended as this distorts the geometry!"
@@ -85,6 +197,30 @@ class GeoTrajectory(GeoData):
 
 
 class GeoMultiTrajectory(GeoData):
+    """CRS-aware wrapper for a collection of path trajectories.
+
+    Accepts several input formats and normalises them to a
+    :class:`~shapely.MultiLineString` internally.
+
+    Args:
+        geometry: One of:
+
+            - :class:`~shapely.MultiLineString` – used directly.
+            - :class:`list` of :class:`~shapely.LineString` – combined into a
+              :class:`~shapely.MultiLineString`.
+            - :class:`list` of :class:`GeoTrajectory` – geometries extracted
+              and combined.
+            - A single :class:`~shapely.LineString` – wrapped in a
+              :class:`~shapely.MultiLineString`.
+
+        crs: Coordinate reference system string.  Defaults to ``"WGS84"``.
+
+    Raises:
+        ValueError: If an element in a list input is not a
+            :class:`~shapely.LineString`, or if a non-list input is not a
+            recognised type.
+    """
+
     def __init__(
         self,
         geometry: (
@@ -112,6 +248,19 @@ class GeoMultiTrajectory(GeoData):
             super().__init__(geometry, crs)
 
     def plot(self, ax=None, add_points=False, color=None, linewidth=2, **kwargs):
+        """Render all trajectories on a Matplotlib axes.
+
+        A warning is issued when the current CRS is ``"WGS84"``.
+
+        Args:
+            ax: Matplotlib :class:`~matplotlib.axes.Axes`.  Defaults to the
+                current active axes.
+            add_points: Overlay vertex markers (default ``False``).
+            color: Line colour accepted by Matplotlib.
+            linewidth: Stroke width in points (default ``2``).
+            **kwargs: Additional keyword arguments forwarded to
+                :func:`shapely.plotting.plot_line`.
+        """
         if self.crs == "WGS84":
             log.warning(
                 "Plotting in WGS84 is not recomended as this distorts the geometry!"
@@ -132,11 +281,30 @@ class GeoMultiTrajectory(GeoData):
 
 
 class GeoPoint(GeoData):
+    """CRS-aware wrapper for a single geographic point.
+
+    Args:
+        geometry: A Shapely :class:`~shapely.Point`.
+        crs: Coordinate reference system string.  Defaults to ``"WGS84"``.
+
+    Raises:
+        ValueError: If *geometry* is not a :class:`~shapely.Point`.
+    """
+
     def __init__(self, geometry: shapely.Point, crs="WGS84"):
         self.is_geometry_of_type(geometry, shapely.Point)
         super().__init__(geometry, crs)
 
     def plot(self, ax=None, add_points=True, color=None, linewidth=2, **kwargs):
+        """Render the point on a Matplotlib axes.
+
+        Args:
+            ax: Matplotlib :class:`~matplotlib.axes.Axes`.
+            add_points: Show the point marker (default ``True``).
+            color: Marker colour.
+            linewidth: Marker size (default ``2``).
+            **kwargs: Forwarded to :func:`shapely.plotting.plot_points`.
+        """
         if self.crs == "WGS84":
             log.warning(
                 "Plotting in WGS84 is not recomended as this distorts the geometry!"
@@ -150,6 +318,19 @@ class GeoPoint(GeoData):
 
 
 class GeoPolygon(GeoData):
+    """CRS-aware wrapper for a simple or holed polygon.
+
+    Args:
+        geometry: A Shapely :class:`~shapely.Polygon` or
+            :class:`~shapely.LineString` (the latter is closed into a
+            polygon automatically).
+        crs: Coordinate reference system string.  Defaults to ``"WGS84"``.
+
+    Raises:
+        ValueError: If *geometry* is neither a
+            :class:`~shapely.Polygon` nor a :class:`~shapely.LineString`.
+    """
+
     def __init__(self, geometry: shapely.Polygon | shapely.LineString, crs="WGS84"):
         self.is_geometry_of_type(geometry, shapely.Polygon | shapely.LineString)
         geometry = shapely.Polygon(geometry)
@@ -177,6 +358,17 @@ class GeoPolygon(GeoData):
         linewidth=2,
         **kwargs,
     ):
+        """Render the polygon on a Matplotlib axes.
+
+        Args:
+            ax: Matplotlib :class:`~matplotlib.axes.Axes`.
+            add_points: Overlay vertex markers (default ``False``).
+            color: Fill and edge colour (overridden by *facecolor*/*edgecolor*).
+            facecolor: Polygon fill colour.
+            edgecolor: Polygon edge colour.
+            linewidth: Edge stroke width in points (default ``2``).
+            **kwargs: Forwarded to :func:`shapely.plotting.plot_polygon`.
+        """
         if self.crs == "WGS84":
             log.warning(
                 "Plotting in WGS84 is not recomended as this distorts the geometry!"
@@ -194,6 +386,18 @@ class GeoPolygon(GeoData):
 
 
 class GeoMultiPolygon(GeoData):
+    """CRS-aware wrapper for a collection of polygons.
+
+    Args:
+        geometry: Either a :class:`~shapely.MultiPolygon` or a
+            :class:`list` of :class:`~shapely.Polygon` objects.
+        crs: Coordinate reference system string.  Defaults to ``"WGS84"``.
+
+    Raises:
+        ValueError: If a list element is not a :class:`~shapely.Polygon`,
+            or if *geometry* is not a :class:`~shapely.MultiPolygon`.
+    """
+
     def __init__(self, geometry, crs="WGS84"):
         if isinstance(geometry, list):
             for geom in geometry:
@@ -227,6 +431,17 @@ class GeoMultiPolygon(GeoData):
         linewidth=2,
         **kwargs,
     ):
+        """Render all polygons on a Matplotlib axes.
+
+        Args:
+            ax: Matplotlib :class:`~matplotlib.axes.Axes`.
+            add_points: Overlay vertex markers (default ``False``).
+            color: Fill and edge colour.
+            facecolor: Polygon fill colour.
+            edgecolor: Polygon edge colour.
+            linewidth: Edge stroke width in points (default ``2``).
+            **kwargs: Forwarded to :func:`shapely.plotting.plot_polygon`.
+        """
         if self.crs == "WGS84":
             log.warning(
                 "Plotting in WGS84 is not recomended as this distorts the geometry!"
@@ -244,6 +459,20 @@ class GeoMultiPolygon(GeoData):
 
 
 def multi_polygon_to_polygon_with_holes(multi_polygon):
+    """Convert a Shapely :class:`~shapely.MultiPolygon` to a CGAL ``PolygonWithHoles``.
+
+    Each polygon in *multi_polygon* is added as a *hole* in the resulting
+    CGAL structure.  This is a low-level helper used internally when passing
+    obstacle geometries to the C++ decomposition kernel.
+
+    Args:
+        multi_polygon: An iterable of Shapely :class:`~shapely.Polygon`
+            objects (typically a :class:`~shapely.MultiPolygon`).
+
+    Returns:
+        bindings.PolygonWithHoles: A CGAL ``Polygon_with_holes_2`` whose
+        holes correspond to the input polygons.
+    """
     # Create an empty CGAL PolygonWithHoles
     polygon_with_holes = bindings.PolygonWithHoles(bindings.Polygon_2())
 
@@ -265,6 +494,18 @@ def multi_polygon_to_polygon_with_holes(multi_polygon):
 
 
 def is_convex(polygon: shapely.Polygon):
+    """Check whether a Shapely polygon is convex.
+
+    Uses the sign of successive cross-products to detect any concavity.  A
+    polygon with fewer than 4 vertices (i.e. a triangle or degenerate shape)
+    is considered non-convex.
+
+    Args:
+        polygon: The :class:`~shapely.Polygon` to test.
+
+    Returns:
+        bool: ``True`` if *polygon* is convex, ``False`` otherwise.
+    """
     coords = polygon.exterior.coords
     num_coords = len(coords)
 
@@ -301,6 +542,20 @@ def is_convex(polygon: shapely.Polygon):
 
 
 def shapely_polygon_to_cgal(polygon: shapely.Polygon):
+    """Convert a Shapely :class:`~shapely.Polygon` to a CGAL ``Polygon_2``.
+
+    Only the exterior ring is transferred; interior rings (holes) are
+    ignored.  The last vertex of the exterior ring is dropped because
+    Shapely closes rings by repeating the first vertex, while CGAL expects
+    an open vertex list.
+
+    Args:
+        polygon: A Shapely :class:`~shapely.Polygon`.
+
+    Returns:
+        bindings.Polygon_2: A CGAL ``Polygon_2`` built from the exterior
+        vertices of *polygon*.
+    """
     # Exctract all the points except the last, as this is the same as the first
     cgal_points = [
         bindings.Point_2(point[0], point[1]) for point in polygon.exterior.coords[:-1]
@@ -310,6 +565,34 @@ def shapely_polygon_to_cgal(polygon: shapely.Polygon):
 
 
 def get_sweep_offset(overlap=0.1, height=10, field_of_view=90):
+    """Calculate the inter-sweep spacing for a given sensor configuration.
+
+    Computes the ground-sample width of the sensor footprint at *height* and
+    scales it by ``(1 - overlap)`` to achieve the desired overlap between
+    adjacent sweep lines.
+
+    Args:
+        overlap: Fractional overlap between adjacent sweeps, in the range
+            ``[0, 1]``.  ``0.0`` means no overlap; ``0.5`` means 50 %
+            overlap.  Defaults to ``0.1``.
+        height: Flight or sensor height above the target surface in metres
+            (default ``10``).
+        field_of_view: Full horizontal field-of-view angle in degrees
+            (default ``90``).
+
+    Returns:
+        float: The recommended distance (in the same units as *height*)
+        between parallel sweep lines.
+
+    Raises:
+        ValueError: If *overlap* is outside the ``[0, 1]`` range.
+
+    Example:
+        ::
+
+            >>> get_sweep_offset(overlap=0.1, height=20, field_of_view=90)
+            36.0
+    """
     if overlap < 0 or overlap > 1:
         msg = "Overlap percentage has to be a float between 0 and 1!"
         raise ValueError(msg)
@@ -356,6 +639,33 @@ def generate_sweep_pattern(
     clockwise=True,
     connect_sweeps=False,
 ):
+    """Generate a boustrophedon sweep pattern over a convex polygon.
+
+    Produces a set of parallel sweep lines (or a single connected path)
+    covering *polygon*.  The underlying algorithm is the C++ sweep
+    implementation from `ethz-asl/polygon_coverage_planning
+    <https://github.com/ethz-asl/polygon_coverage_planning>`_ exposed via
+    pybind11 bindings.
+
+    Args:
+        polygon: The :class:`~shapely.Polygon` to sweep.  Should be a
+            convex cell; for non-convex areas call :func:`decompose_polygon`
+            first.
+        sweep_offset: Distance in the polygon's CRS units between adjacent
+            parallel sweep lines.  Use :func:`get_sweep_offset` to derive
+            this from sensor parameters.
+        clockwise: Sweep direction.  ``True`` (default) starts at the
+            clockwise end of each row.
+        connect_sweeps: When ``True``, all sweep segments are concatenated
+            into a single :class:`~shapely.LineString` (suitable for
+            continuous path execution).  When ``False`` (default) each
+            segment is returned as a separate :class:`~shapely.LineString`.
+
+    Returns:
+        list[shapely.LineString]: A list of sweep line segments, or a
+        single-element list containing the connected path when
+        *connect_sweeps* is ``True``.
+    """
     # Snap coordinates to 10 cm precision to remove pyproj floating-point noise
     # that can cause CGAL to SIGSEGV on otherwise valid polygon inputs.
     polygon = _snap_polygon(polygon)
@@ -387,6 +697,32 @@ def generate_sweep_pattern(
 def decompose_polygon(
     boundary: shapely.Polygon, obstacles: shapely.MultiPolygon | shapely.Polygon = None
 ):
+    """Decompose a polygon (with optional obstacles) into convex cells.
+
+    Uses the Boustrophedon Cell Decomposition algorithm implemented in CGAL
+    (via pybind11 bindings) to split *boundary* into a set of convex,
+    weakly-monotone sub-polygons.  Each returned cell can be passed directly
+    to :func:`generate_sweep_pattern`.
+
+    When an obstacle intersects the boundary edge, the two geometries are
+    merged so that the boundary is expanded to include the overlapping
+    obstacle region rather than creating a degenerate hole.
+
+    Args:
+        boundary: The outer boundary polygon to decompose.
+        obstacles: Optional obstacles (keep-out zones) inside *boundary*.
+            Accepts a single :class:`~shapely.Polygon` or a
+            :class:`~shapely.MultiPolygon`.  Pass ``None`` (default) for an
+            obstacle-free area.
+
+    Returns:
+        list[shapely.Polygon]: The convex decomposition cells.  Each cell is
+        a simple :class:`~shapely.Polygon` with no holes.
+
+    Raises:
+        ValueError: If *obstacles* is provided but is neither a
+            :class:`~shapely.Polygon` nor a :class:`~shapely.MultiPolygon`.
+    """
     # Snap coordinates to 10 cm precision to remove pyproj floating-point noise
     # that can cause CGAL to SIGSEGV on otherwise valid polygon inputs.
     boundary = _snap_polygon(boundary)

--- a/trajgenpy/Logging.py
+++ b/trajgenpy/Logging.py
@@ -1,3 +1,19 @@
+"""Coloured logging setup for TrajGenPy.
+
+This module configures a :mod:`logging` logger named ``"trajgenpy"`` with
+ANSI colour formatting via `colorama <https://pypi.org/project/colorama/>`_.
+Each log level is rendered in a distinct colour:
+
+- **TRACE** – magenta
+- **DEBUG** – blue
+- **INFO** – green
+- **WARNING** – yellow
+- **ERROR** – red
+
+The logger is initialised automatically when the module is first imported.
+All TrajGenPy modules obtain the logger via :func:`get_logger`.
+"""
+
 import inspect
 import logging
 from pathlib import Path
@@ -8,6 +24,21 @@ LOGGER_NAME = "trajgenpy"
 
 
 def init_logger():
+    """Initialise and return the ``"trajgenpy"`` logger.
+
+    Creates a :class:`logging.StreamHandler` with a
+    :class:`~logging.Formatter` that prepends ANSI colour codes to the log
+    level name and appends the originating file name and line number.  The
+    logger level is set to ``DEBUG`` so that all messages are forwarded to
+    handlers; adjust individual handlers if a higher threshold is desired.
+
+    Calling this function more than once is safe — the handler is always
+    attached, but :func:`get_logger` should be preferred for normal usage
+    as it returns the existing logger without re-initialising it.
+
+    Returns:
+        logging.Logger: The configured ``"trajgenpy"`` logger instance.
+    """
     # Initialize colorama to support ANSI color codes on Windows
     colorama.init()
 
@@ -45,35 +76,17 @@ def init_logger():
 
 
 def get_logger():
+    """Return the ``"trajgenpy"`` logger.
+
+    If the logger has not been initialised yet (no handlers attached),
+    :func:`init_logger` is called automatically.  This function is the
+    preferred way to obtain the logger from within TrajGenPy modules.
+
+    Returns:
+        logging.Logger: The ``"trajgenpy"`` logger instance.
+    """
     return logging.getLogger(LOGGER_NAME)
 
 
 if get_logger().handlers == []:
     init_logger()
-
-
-# def debug(*args, **kwargs):
-#     message = " ".join(map(str, args))
-#     logging.getLogger(LOGGER_NAME).debug(message, **kwargs)
-
-
-# def info(*args, **kwargs):
-#     message = " ".join(map(str, args))
-#     logging.getLogger(LOGGER_NAME).info(message, **kwargs)
-
-
-# def warning(*args, **kwargs):
-#     message = " ".join(map(str, args))
-#     logging.getLogger(LOGGER_NAME).warning(message, **kwargs)
-
-
-# def error(*args, **kwargs):
-#     message = " ".join(map(str, args))
-#     logging.getLogger(LOGGER_NAME).error(message, **kwargs)
-
-
-# if __name__ == "__main__":
-#     debug("This is a debug message")
-#     info("This is an info message")
-#     warning("This is a warning message")
-#     error("This is an error message")

--- a/trajgenpy/Query.py
+++ b/trajgenpy/Query.py
@@ -1,3 +1,22 @@
+"""OpenStreetMap feature querying utilities.
+
+This module wraps `OSMnx <https://osmnx.readthedocs.io/>`_ to provide a
+simplified interface for extracting geographic features from OpenStreetMap
+within a given area of interest and exporting results to GeoJSON.
+
+Example:
+    ::
+
+        from trajgenpy.Geometries import GeoPolygon
+        from trajgenpy.Query import query_features, export_as_geojson
+        import shapely
+
+        area = GeoPolygon(shapely.box(10.38, 55.38, 10.42, 55.42))
+
+        tags = {"landuse": True, "natural": True}
+        features = query_features(area, tags)
+"""
+
 from pathlib import Path
 
 import osmnx as ox
@@ -11,6 +30,37 @@ log = Logging.get_logger()
 
 
 def query_features(area: GeoPolygon, tags: dict):
+    """Query OpenStreetMap features within a geographic area.
+
+    Fetches all OSM features whose tags match *tags* and clips the result to
+    *area*.  The area geometry must use the ``"WGS84"`` CRS because OSM
+    data is stored in geographic coordinates.
+
+    Args:
+        area: The region of interest as a :class:`~trajgenpy.Geometries.GeoPolygon`
+            in ``"WGS84"`` CRS.
+        tags: A dictionary of OSM tag keys (and optional values) to query.
+            Use ``{key: True}`` to fetch all features with a given key
+            regardless of value, or ``{key: value}`` to filter by a
+            specific value.  See the `OSM map features wiki
+            <https://wiki.openstreetmap.org/wiki/Map_features>`_ for valid
+            tag combinations.
+
+    Returns:
+        dict[str, shapely.geometry.base.BaseGeometry]: A dictionary mapping
+        each requested tag key to the union of all matching geometries
+        clipped to *area*.  An empty list is returned on query failure.
+
+    Raises:
+        ValueError: If *area* does not use the ``"WGS84"`` CRS.
+
+    Example:
+        ::
+
+            tags = {"natural": True, "landuse": ["forest", "farmland"]}
+            results = query_features(area, tags)
+            forest_geom = results.get("natural")
+    """
     # Check that the geometry has the right crs
     if not area.crs and area.crs != "WGS84":
         msg = "The geometry must use WGS84 CRS!"
@@ -36,6 +86,26 @@ def query_features(area: GeoPolygon, tags: dict):
 
 
 def export_as_geojson(boundary: shapely.Polygon, obstacles, features, crs):
+    """Export boundary, obstacles, and task features to a GeoJSON file.
+
+    Writes a ``FeatureCollection`` containing three named features — the
+    coverage boundary, obstacle polygons, and task trajectories — to a file
+    called ``output.json`` in the current working directory.
+
+    Args:
+        boundary: The outer boundary :class:`~shapely.Polygon`.
+        obstacles: An iterable of obstacle :class:`~shapely.Polygon` objects.
+        features: An iterable of :class:`~shapely.LineString` trajectory
+            segments representing the coverage tasks.
+        crs: CRS identifier string stored as metadata in the GeoJSON output
+            (e.g. ``"EPSG:32632"``).
+
+    Returns:
+        None
+
+    Side effects:
+        Creates (or overwrites) ``output.json`` in the current directory.
+    """
     boundary_feature = Feature(geometry=boundary, id="boundary")
     obstacles_feature = Feature(
         geometry=shapely.MultiPolygon(obstacles), id="obstacles"

--- a/trajgenpy/Utils.py
+++ b/trajgenpy/Utils.py
@@ -1,19 +1,67 @@
+"""Visualisation and coordinate utility helpers.
+
+This module provides convenience functions for:
+
+- Overlaying tile-based basemaps on Matplotlib figures using
+  `contextily <https://contextily.readthedocs.io/>`_.
+- Normalising geometry coordinates relative to a bounding box origin, which
+  is useful for producing metric plots that start at ``(0, 0)``.
+"""
+
 import contextily as ctx
 import matplotlib.pyplot as plt
 import shapely
 from shapely.affinity import translate
 
-# Example usage:
 
-
-# A function to plot a map using the contextily library
 def plot_basemap(ax=None, provider=ctx.providers.Esri.WorldImagery, crs="WGS84"):
+    """Overlay a tile-based basemap on a Matplotlib axes.
+
+    Uses :func:`contextily.add_basemap` to fetch and render web map tiles
+    behind any geometries already plotted on *ax*.  The axes must already
+    have geographic extent set (e.g. by plotting a GeoPolygon first).
+
+    Args:
+        ax: Matplotlib :class:`~matplotlib.axes.Axes` to draw on.  Defaults
+            to :func:`matplotlib.pyplot.gca` when ``None``.
+        provider: Tile provider descriptor from ``contextily.providers``
+            (default: ``ctx.providers.Esri.WorldImagery``).  See the
+            `contextily providers documentation
+            <https://contextily.readthedocs.io/en/latest/providers_deepdive.html>`_
+            for a full list of available providers.
+        crs: CRS of the axes coordinates (default ``"WGS84"``).  Pass an
+            EPSG string (e.g. ``"EPSG:32632"``) when the axes are in a
+            projected coordinate system.
+
+    Returns:
+        The return value of :func:`contextily.add_basemap` (typically
+        ``None``).
+    """
     if ax is None:
         ax = plt.gca()
     return ctx.add_basemap(ax, source=provider, crs=crs)
 
 
 def normalize_coordinates(boundary, geometries=None):
+    """Translate geometries so that the bounding-box origin is at ``(0, 0)``.
+
+    Shifts all geometries in *geometries* by the negative of the lower-left
+    corner of *boundary*'s bounding box.  This produces a local coordinate
+    frame suitable for visualisation or downstream algorithms that expect
+    metric coordinates starting at the origin.
+
+    Args:
+        boundary: A Shapely geometry whose :attr:`~shapely.Geometry.bounds`
+            define the translation offset.
+        geometries: A Shapely geometry collection (e.g.
+            :class:`~shapely.MultiLineString`) whose individual geometries
+            will be translated.  Each element in ``geometries.geoms`` is
+            processed separately.
+
+    Returns:
+        list[shapely.geometry.base.BaseGeometry]: A list of translated
+        geometries in the same order as ``geometries.geoms``.
+    """
     normalized_geoms = []
     translation_vector = shapely.Point(boundary.bounds[0], boundary.bounds[1])
     for geom in list(geometries.geoms):
@@ -22,83 +70,3 @@ def normalize_coordinates(boundary, geometries=None):
         )
 
     return normalized_geoms
-
-
-# lines = MultiLineString(
-#     [LineString([(100, 100), (200, 200)]), LineString([(300, 300), (400, 400)])]
-# )
-# image_width = 800
-# image_height = 600
-# resulting_image = create_image_from_multilinestring(lines, image_width, image_height)
-
-
-# import cv2
-# def create_image_from_multilinestring(
-#     multilinestring: shapely.MultiLineString,
-#     thickness=5,
-#     line_sigma=5,
-#     intensity=10,
-#     line_color=(0, 0, 255),
-# ):
-#     # Create a blank white image
-#     image_width = int(multilinestring.bounds[2]) + 100
-#     image_height = int(multilinestring.bounds[3]) + 100
-#     image = np.zeros((image_height, image_width), np.uint8)
-
-#     # Convert MultiLineString to a list of LineStrings
-#     linestrings = list(multilinestring.geoms)
-#     for linestring in linestrings:
-#         coords = np.array(linestring.coords)
-
-#         # Iterate over each pair of points and interpolate
-#         for i in range(len(coords) - 1):
-#             x1, y1 = coords[i]
-#             x2, y2 = coords[i + 1]
-
-#             # Create a Gaussian line kernel
-#             line_kernel = np.zeros((image_height, image_width), np.uint8)
-#             # cv2.rectangle(
-#             #     line_kernel,
-#             #     (int(x1), int(y1)),
-#             #     (int(x2), int(y2)),
-#             #     intensity,
-#             #     thickness,
-#             # )
-
-#             cv2.line(
-#                 line_kernel,
-#                 (int(x1), int(y1)),
-#                 (int(x2), int(y2)),
-#                 intensity,
-#                 thickness,
-#             )
-
-#             # Apply Gaussian blur to the line kernel
-#             line_kernel = gaussian_filter(line_kernel, sigma=line_sigma)
-#             # Add the colored line to the image
-#             image = np.clip(
-#                 image.astype(np.int64) + line_kernel.astype(np.int64), 0, 255
-#             ).astype(np.uint8)
-
-#     cv2.flip(image, 0, image)
-#     image = cv2.normalize(image, image, 0, 255, cv2.NORM_MINMAX)
-
-#     image = cv2.applyColorMap(image, cv2.COLORMAP_JET)
-#     # Display and save the resulting image
-#     # cv2.imshow("Image with Colored Gaussian Lines", image)
-#     # cv2.waitKey(0)
-#     # cv2.destroyAllWindows()
-#     cv2.imwrite("image_with_colored_gaussian_lines.png", image)
-
-#     return image
-
-
-# # trajectory_list = Utils.normalize_coordinates(
-# #     geo_poly.geometry, multi_traj.get_geometry()
-# # )
-
-# # Utils.create_image_from_multilinestring(
-# #     shapely.MultiLineString(trajectory_list),
-# #     thickness=int(offset * 1.2),
-# #     intensity=30,
-# # )

--- a/trajgenpy/__init__.py
+++ b/trajgenpy/__init__.py
@@ -1,3 +1,40 @@
+"""TrajGenPy: Coverage trajectory generation using Boustrophedon Cell Decomposition.
+
+TrajGenPy is a Python library for generating coverage trajectories over arbitrary
+polygonal areas, with optional obstacle avoidance.  It is built on top of a C++
+implementation of the Boustrophedon Cell Decomposition algorithm (via CGAL and
+pybind11) and provides a high-level Python API for:
+
+- Querying environmental features from OpenStreetMap (OSM).
+- Converting geometries between coordinate reference systems (CRS).
+- Decomposing polygons (with holes) into convex, weakly-monotone cells.
+- Generating boustrophedon ("lawnmower") sweep patterns over each cell.
+
+Example:
+    A minimal end-to-end workflow::
+
+        import shapely
+        from trajgenpy.Geometries import (
+            GeoPolygon,
+            decompose_polygon,
+            generate_sweep_pattern,
+            get_sweep_offset,
+        )
+
+        # 1. Define an area of interest in WGS84
+        area = GeoPolygon(shapely.box(10.38, 55.38, 10.42, 55.42))
+
+        # 2. Reproject to a metric CRS (UTM zone 32N) for planning
+        area.set_crs("EPSG:32632")
+
+        # 3. Decompose into convex cells
+        cells = decompose_polygon(area.geometry)
+
+        # 4. Generate a boustrophedon sweep for each cell
+        offset = get_sweep_offset(overlap=0.1, height=20, field_of_view=90)
+        sweeps = [generate_sweep_pattern(cell, offset) for cell in cells]
+"""
+
 from importlib.metadata import PackageNotFoundError, version as _package_version
 
 try:
@@ -6,4 +43,5 @@ except PackageNotFoundError:
     __version__ = "dev"
 
 from trajgenpy import Geometries, Query, Utils
+
 __all__ = ["__doc__", "__version__", "Geometries", "Query", "Utils"]


### PR DESCRIPTION
- Add Google-style docstrings to all public modules (Geometries, Query,
  Utils, Logging, __init__) covering every class, method, and function.
- Set up MkDocs with Material theme (mkdocs.yml): navigation tabs,
  dark/light mode toggle, code copy, search, and pymdownx extensions.
- Create docs/ directory with index, installation, quickstart, API
  reference (auto-generated via mkdocstrings), examples, and contributing
  pages.
- Add .github/workflows/docs.yml: builds the library (needed for
  mkdocstrings introspection) then deploys to GitHub Pages on every push
  to main via `mkdocs gh-deploy`.
- Add `docs` optional-dependency group to pyproject.toml.

https://claude.ai/code/session_01Xewn3Qp7ZCZjjTThdRxSmG